### PR TITLE
(fix) handle empty documents error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
   "author": "Derek Nguyen <derek@penandpillow.com>",
   "license": "MIT",
   "dependencies": {
-    "@graphql-codegen/core": "^1.2.1",
-    "@graphql-codegen/typescript": "^1.2.1",
-    "@graphql-codegen/typescript-operations": "^1.2.1",
-    "fork-ts-checker-webpack-plugin": "^1.3.6",
+    "@graphql-codegen/core": "^1.4.0",
+    "@graphql-codegen/typescript": "^1.4.0",
+    "@graphql-codegen/typescript-operations": "^1.4.0",
+    "fork-ts-checker-webpack-plugin": "^1.4.3",
     "fs-extra": "^7.0.1",
+    "graphql-tag-pluck": "^0.8.3",
     "graphql-toolkit": "^0.5.0",
     "lodash.debounce": "^4.0.8",
-    "ts-loader": "^6.0.2"
+    "ts-loader": "^6.0.4"
   },
   "peerDependencies": {
     "gatsby": "^2.9.2",

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -81,7 +81,7 @@ export const onPostBootstrap: GatsbyNode["onPostBootstrap"] = async (
   const { schema, program } = store.getState()
   const { directory } = program
   const generateFromSchema = await generateWithConfig({
-    directory, fileName
+    directory, fileName, reporter
   })
 
   const build = async (schema: any) => {

--- a/src/graphql-codegen.config.ts
+++ b/src/graphql-codegen.config.ts
@@ -24,12 +24,19 @@ const createConfig: CreateConfig = async ({ directory, fileName }) => {
     const docPromises = [
       './src/**/*.{ts,tsx}',
       './.cache/fragments/*.js',
-    ].map(docGlob => {
+    ].map(async docGlob => {
       const _docGlob = path.join(directory, docGlob)
-      return loadDocuments(_docGlob)
+      return loadDocuments(_docGlob).catch(err => {
+        console.log('catched')
+        console.log(err)
+      })
     })
     const results = await Promise.all(docPromises)
-    const documents = results.reduce((acc, cur) => acc.concat(cur), [])
+    const documents = results.reduce((acc, cur) => {
+      if (!cur) return acc
+      // @ts-ignore
+      return acc.concat(cur)
+    }, [])
 
     return {
       filename: pathToFile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,7 +785,7 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-"@graphql-codegen/core@^1.2.1":
+"@graphql-codegen/core@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.4.0.tgz#dc3ef765706e0ba0b93d446dee3aba7eeb615cd6"
   integrity sha512-8Lhir7t6N5o7AjN8RlJ3r7fseIh4b5Mh9lhEOFYiH3WMdxouN59P18edd2pQX5TOK+TBg9Gxyaa9bFPM90kP5w==
@@ -804,7 +804,7 @@
     import-from "3.0.0"
     tslib "1.10.0"
 
-"@graphql-codegen/typescript-operations@^1.2.1":
+"@graphql-codegen/typescript-operations@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-1.4.0.tgz#2bc4692c9b1b168eb23fb3d8c73732d21fb55eec"
   integrity sha512-VMQb/vccqJOEeYt7pPrWDFpvdL5z5L+axLCp/pnPv0v4fzSFuRMO5m8+VWej+q/DLd9dzFY/vGmMPo6Bq46+XQ==
@@ -814,7 +814,7 @@
     "@graphql-codegen/visitor-plugin-common" "1.4.0"
     tslib "1.10.0"
 
-"@graphql-codegen/typescript@1.4.0", "@graphql-codegen/typescript@^1.2.1":
+"@graphql-codegen/typescript@1.4.0", "@graphql-codegen/typescript@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-1.4.0.tgz#8c920643310ad05522b7609a9cd48d1663a6c71d"
   integrity sha512-JYBEMJdT4IBlbf8L1chrLz2YARBJuYvXi+bdGqNmfmv1AdVbTYpRz1qhqRWOneMg9sdYUxVFUhvZ4lD9PM3FGg==
@@ -4244,7 +4244,7 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
-fork-ts-checker-webpack-plugin@^1.3.6:
+fork-ts-checker-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.4.3.tgz#2252c1f8ad1b25313e056835d939b423ea240cd6"
   integrity sha512-srf43Z3B1hCJNrwCG78DbHmWgKQUqHKsvFbLP182gank28j9s05KJbSZaMKBA0b6Pqi0LBLpAFWeB0JPbc1iLQ==
@@ -4829,6 +4829,16 @@ graphql-request@^1.5.0:
   integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
   dependencies:
     cross-fetch "2.2.2"
+
+graphql-tag-pluck@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/graphql-tag-pluck/-/graphql-tag-pluck-0.8.3.tgz#4353510fc9577926529bf643213b3945aec50431"
+  integrity sha512-I03pf3qoteLoqvx23Yjk9OanOEkQZgwgEOcvYSnJZs92BADko/NXNOCpvvsGQ/suHKqM1p4uXv0fYHJ9oKHxrw==
+  dependencies:
+    "@babel/parser" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    source-map-support "^0.5.12"
 
 graphql-tag@2.10.1:
   version "2.10.1"
@@ -8890,7 +8900,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@~0.5.10, source-map-support@~0.5.12:
+source-map-support@^0.5.12, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
@@ -9440,7 +9450,7 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
-ts-loader@^6.0.2:
+ts-loader@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.0.4.tgz#bc331ad91a887a60632d94c9f79448666f2c4b63"
   integrity sha512-p2zJYe7OtwR+49kv4gs7v4dMrfYD1IPpOtqiSPCbe8oR+4zEBtdHwzM7A7M91F+suReqgzZrlClk4LRSSp882g==


### PR DESCRIPTION
- Handle empty loadDocuments error, restore the previous behavior of showing warning instead
- Upgrade remaining codegen packages to latest versions
- Add `graphql-tag-pluck`, since it no longer comes with `graphql-toolkit`

Fix #15 