### PR TITLE
Feat/typecheck

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0
+- typecheck: allow user to pass in options for [`fork-ts-checker-webpack-plugin`](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options)
+- typecheck: #22: remove `alwaysCheck`, allow user to simply set `typeCheck` to enable / disable type checking completely. Previous behavior can be preserved by setting the following options in `gatsby-config.js`:
+
+```js
+{
+  resolve: 'gatsby-plugin-ts',
+  options: {
+    // Disable type checking in production
+    typeCheck: process.env.NODE_ENV !== 'production',
+  }
+}
+```
+
 ## 1.3.3
 - fix #15 where empty documents break build; display warning instead of throwing error
 - more greenkeeping

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,10 @@ In order for this plugin to work right, you'd need to set your compile options l
     "lib": ["dom"],             /* <-- required! */
     "jsx": "preserve",          /* <-- required! */
     "moduleResolution": "node", /* <-- required! */
+
+    /* for mixed ts/js codebase */
+    "allowJS": true,
+    "outDir": "./build"    /* this won't be used by ts-loader */
     /* other options... */
   }
 
@@ -50,7 +54,9 @@ In order for this plugin to work right, you'd need to set your compile options l
 |options.codegen| `true` | enable / disable generating definitions for graphql queries|
 |options.fileName| `graphql-type.ts` | path to the generated file. By default, it's placed at the project root directory & it should not be placed into `src`, since this will create an infinite loop|
 |options.codegenDelay| `200` | amount of delay from file change to codegen|
-|options.alwaysCheck | `false` | enable type checking during production build|
+|options.alwaysCheck | `false` | (⚠️deprecated, see this note) By default type checking is disabled in production mode (during `gatsby build`). Set this to `true` to enable type checking in production as well |
+|options.typeCheck | `true` | Enable / disable type checking with `fork-ts-checker-webpack-plugin`. |
+|options.forkTsCheckerPlugin | `{}` | Options that'll be passed to `fork-ts-checker-webpack-plugin`. For all options, please see [their docs](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options)
 
 An example with all available settings:
 
@@ -61,6 +67,9 @@ An example with all available settings:
   options: {
     tsLoader: {
       logLevel: 'warn',
+    },
+    forkTsCheckerPlugin: {
+      eslint: true,
     },
     fileName: `types/graphql-types.ts`,
     codegen: true,
@@ -115,5 +124,19 @@ interface IBlogIndexProps {
 
 const BlogIndex: React.FC<IBlogIndexProps> = ({ data, location }) => {
   ...
+}
+```
+
+## Disable type checking in production
+
+Previously this plugin disable type checking in production by default, which can be changed by setting `alwaysCheck` to `true`. Since 2.0.0 it no longer does this. If you want to preseve the previous behavior, please set the `typeCheck` option like below:
+
+```js
+{
+  resolve: 'gatsby-plugin-ts',
+  options: {
+    // Disable type checking in production
+    typeCheck: process.env.NODE_ENV !== 'production',
+  }
 }
 ```

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -8,6 +8,7 @@ import debounce from 'lodash.debounce'
 export interface TsOptions extends PluginOptions {
   tsLoader?: Partial<tsloader.Options>;
   typeCheck?: boolean;
+  alwaysCheck?: boolean;
   forkTsCheckerPlugin?: Partial<FTCWebpackPlugin.Options>;
   fileName?: string;
   codegen?: boolean;
@@ -18,6 +19,7 @@ const defaultOptions: TsOptions = {
   plugins: [],
   tsLoader: {},
   typeCheck: true,
+  alwaysCheck: false,
   forkTsCheckerPlugin: {},
   fileName: 'graphql-types.ts',
   codegen: true,
@@ -115,6 +117,10 @@ export const onPostBootstrap: GatsbyNode["onPostBootstrap"] = async (
 }
 
 export const onPreInit: GatsbyNode['onPreInit'] = ({ reporter }, options: TsOptions) => {
+  const { alwaysCheck } = options
   const { typeCheck } = getOptions(options)
+  if (typeof alwaysCheck !== 'undefined') {
+    reporter.warn(`[gatsby-plugin-ts] \`alwaysCheck\` has been deprecated. Please set \`typeCheck\` instead.`)
+  }
   reporter.info(`[gatsby-plugin-ts] Typecheck is ${typeCheck ? 'enabled' : 'disabled'}.`)
 }


### PR DESCRIPTION
#22

- allow user to pass in options for fork-ts-webpack-plugin
- remove `alwaysCheck`, simply enable or disable type checking with `typeCheck`